### PR TITLE
First-time data transform bugfix

### DIFF
--- a/privateer_ad/etl/transform.py
+++ b/privateer_ad/etl/transform.py
@@ -301,14 +301,14 @@ class DataProcessor:
         # Ensure a processed directory exists
         self.paths_config.processed_dir.mkdir(parents=True, exist_ok=True)
 
-        # Setup and save scalers using training data
-        self.setup_scalers()
-
         logging.info('Save datasets...')
         for k, df in datasets.items():
-            save_path = get_dataset_path(k)
+            save_path = self.paths_config.processed_dir.joinpath(f"{k}.csv")
             df.to_csv(save_path, index=False)
             logging.info(f'{k} saved at {save_path}')
+        
+        # Setup and save scalers using training data
+        self.setup_scalers()
 
     def setup_scalers(self) -> None:
         """Sets up data scalers using only benign training samples for normalization.
@@ -595,6 +595,8 @@ class DataProcessor:
 
 if __name__ == '__main__':
     dp = DataProcessor()
+    # Uncomment it to prepare the dataset, from the raw data
+    # dp.prepare_datasets()
     dl = dp.get_dataloader('val', train=False)
     for i, sample in enumerate(dl):
         print(sample[0]['encoder_cont'][0, 0])

--- a/privateer_ad/etl/utils.py
+++ b/privateer_ad/etl/utils.py
@@ -50,7 +50,8 @@ def check_existing_datasets():
         >>> check_existing_datasets()  # Raises FileExistsError if train.csv exists
         FileExistsError: File /path/to/processed/train.csv exists.
     """
+    paths_config = PathConfig()
     for mode in ['train', 'val', 'test']:
-        path = get_dataset_path(mode)
-        if os.path.exists(path):
+        path = paths_config.processed_dir.joinpath(f"{mode}.csv")
+        if path.exists():
             raise FileExistsError(f'File {path} exists.')


### PR DESCRIPTION
Solves the following bug, when converting the data from raw to processed
```bash
root@coroni:/app# python3 privateer_ad/etl/transform.py
INFO:root:Initializing DataProcessor...
INFO:root:Loaded data from
/app/data/raw/amari_ue_data_merged_with_attack_number.csv
INFO:root:Setting up scalers from benign training data only...
WARNING:root:Found 580 NaT values in _time column.
INFO:root:Using 514430 benign samples out of 548101 total training
samples for scaling
Traceback (most recent call last):
  File "/app/privateer_ad/etl/transform.py", line 583, in <module>
    dp.prepare_datasets()
  File "/app/privateer_ad/etl/transform.py", line 115, in prepare_datasets
    self._save_scalers()
  File "/app/privateer_ad/etl/transform.py", line 203, in _save_scalers
    joblib.dump(self.scalers[feature_name], scaler_path)
                ~~~~~~~~~~~~^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable 
```